### PR TITLE
Avoid lazy seqs

### DIFF
--- a/src/main/clojure/clojure/spec/alpha.cljc
+++ b/src/main/clojure/clojure/spec/alpha.cljc
@@ -1506,8 +1506,10 @@
                         (c/or (seq ks) (repeat nil))
                         (c/or (seq forms) (repeat nil)))
                    (filter #(-> % first f)))]
-      [(seq (map first pks)) (when ks (seq (map second pks))) (when forms (seq (map #(nth % 2) pks)))])
-    [(seq (filter f ps)) ks forms]))
+      [(#?(:clj seq :clje clj_rt/to_list) (map first pks))
+       (when ks (#?(:clj seq :clje clj_rt/to_list) (map second pks)))
+       (when forms (#?(:clj seq :clje clj_rt/to_list) (map #(nth % 2) pks)))])
+    [(#?(:clj seq :clje clj_rt/to_list) (filter f ps)) ks forms]))
 
 (defn- alt* [ps ks forms]
   (let [[[p1 & pr :as ps] [k1 :as ks] forms] (filter-alt ps ks forms identity)]


### PR DESCRIPTION
Even though Clojure on the BEAM includes support for lazy seqs, they are not to suitable to be used in the same way as in Clojure on the JVM, since the values calculated are not cached and end up being recalculated every time the seq is iterated on.

An approach to work around this situation is to convert these lazy seqs to Erlang lists witht the `clj_rt/to_list` function.